### PR TITLE
Support Config File Directory Specification of Various Platforms

### DIFF
--- a/macast/utils.py
+++ b/macast/utils.py
@@ -6,24 +6,19 @@ import socket
 import uuid
 import json
 import ctypes
+import appdirs
 import logging
 import platform
 import locale
 import subprocess
 from enum import Enum
+if sys.platform == 'darwin':
+    from AppKit import NSBundle
 
 logger = logging.getLogger("Utils")
 PORT = 1068
 
-if sys.platform == 'darwin':
-    from AppKit import NSBundle
-    SETTING_DIR = os.path.join(os.environ['HOME'],
-                               'Library/Application Support/Macast')
-elif sys.platform == 'win32':
-    SETTING_DIR = 'C:\\ProgramData\\Macast'
-else:
-    SETTING_DIR = os.getcwd()
-
+SETTING_DIR = appdirs.user_config_dir('Macast', 'xfangfang')
 
 class SettingProperty(Enum):
     USN = 0

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,3 +1,4 @@
+appdirs
 cherrypy
 lxml
 requests

--- a/requirements/darwin.txt
+++ b/requirements/darwin.txt
@@ -1,3 +1,4 @@
+appdirs
 cherrypy
 lxml
 requests


### PR DESCRIPTION
As for now, Macast has the config file directory hardcoded, reading and writing the config file in a fixed folder. For some users, this makes a little difficult to manage their config files, especially for Linux desktop users who don't want annoying dot files in their $HOME.

So I introduce `appdirs` module in this PR to fix #20 ,  it's very convenient to use it to get user config directory. For Linux, it meets XDG Base Directory specification while meets the specification of macOS and Windows at the same time.

[As @icepie says](https://github.com/xfangfang/Macast/issues/20#issuecomment-903307017), ```$HOME/.config/macast``` can also apply for all platforms, just ```from pathlib import Path``` and invoke ```Path.home()``` to find ```$HOME```. I just pick one of various methods in this case.

*This PR compare the branch with `dev`.*