### PR TITLE
add start at login for win32

### DIFF
--- a/macast/macast.py
+++ b/macast/macast.py
@@ -399,11 +399,14 @@ class Macast(App):
                 self.renderer_menuitem.children[0].checked = True
 
         platform_options = []
-        if sys.platform == 'darwin':
+        """To judge whether Macast was launched by scripts or by packaged app.
+        """
+        if sys.platform != 'linux' and "python" not in os.path.basename(sys.executable).lower():
             platform_options = [self.start_at_login_menuitem]
             # Reset StartAtLogin to prevent the user from turning off
             # this option from the system settings
             Setting.set_start_at_login(self.setting_start_at_login)
+        if sys.platform == 'darwin':
             self.menubar_icon_menuitem = MenuItem(_("Menubar Icon"),
                                                   children=App.build_menu_item_group([
                                                       _("AppIcon"),

--- a/macast/utils.py
+++ b/macast/utils.py
@@ -16,6 +16,8 @@ from enum import Enum
 import netifaces as ni
 if sys.platform == 'darwin':
     from AppKit import NSBundle
+elif sys.platform == 'win32':
+    import win32com.client as client
 
 logger = logging.getLogger("Utils")
 DEFAULT_PORT = 1068
@@ -237,6 +239,28 @@ class Setting:
                      'tell application "System Events" ' +
                      'to delete login item "{}"'.format(app_name)])
             return res
+        elif sys.platform == 'win32':
+            """Find the path of Macast.exe so as to create shortcut.
+            """
+            shell = client.Dispatch("WScript.Shell")
+            startup_path = r'%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup'
+            if launch:
+                try:
+                    os.remove(os.path.join(startup_path, 'Macast.lnk'))
+                except IOError:
+                    pass
+
+                macast_path = sys.executable
+                macast_shortcut = shell.CreateShortCut(os.path.join(startup_path, 'Macast.lnk'))
+                macast_shortcut.TargetPath = macast_path
+                macast_shortcut.save()
+                return 0, 1
+            else:
+                try:
+                    os.remove(os.path.join(startup_path, 'Macast.lnk'))
+                except IOError:
+                    return (0, "there's no macast shortcut.")
+                return 0, 1
         else:
             return (1, 'Not support current platform.')
 


### PR DESCRIPTION
Firstly, when building the setting menu on Windows, judge whether Macast launch from source code or packaged app.
- If Macast launch from source code, do nothing.
- If Macast launch from packaged app, build a **start at login** item in the menu.

Secondly, when **start at login** was checked, try deleting the possibly existed shortcut so as to prevent there's an older version Macast shortcut. Then create a shortcut in the **Startup** folder.

Thirdly, when  **start at login** was unchecked, delete the shortcut in the **Startup** folder.