### PR TITLE
Add Singleton support

### DIFF
--- a/Macast.py
+++ b/Macast.py
@@ -4,8 +4,12 @@ import os
 import sys
 import gettext
 import logging
+from tendo import singleton
+
+
 from macast import Setting, SETTING_DIR
 from macast.macast import gui
+from macast.utils import SettingProperty
 
 logger = logging.getLogger("Macast")
 logger.setLevel(logging.DEBUG)
@@ -44,6 +48,10 @@ def get_lang():
         logger.error("Macast Loading Default Language en_US")
 
 
+def get_single_mode():
+    singleMode = Setting.get(SettingProperty.SingleMode)
+    return singleMode
+
 def clear_env():
     # todo clear pyinstaller file on start
     log_path = os.path.join(SETTING_DIR, 'macast.log')
@@ -57,4 +65,9 @@ if __name__ == '__main__':
     clear_env()
     get_lang()
     set_mpv_default_path()
+    if get_single_mode():
+        try:
+            me = singleton.SingleInstance()
+        except singleton.SingleInstanceException:
+            sys.exit(-1)
     gui(lang=_)

--- a/macast/utils.py
+++ b/macast/utils.py
@@ -39,6 +39,7 @@ class SettingProperty(Enum):
     Macast_Protocol = 7
     Blocked_Interfaces = 8
     Additional_Interfaces = 9
+    SingleMode = 10
 
 
 class Setting:
@@ -201,6 +202,7 @@ class Setting:
         """
         if not bool(Setting.setting):
             Setting.load()
+            print(property)
         if property.name in Setting.setting:
             return Setting.setting[property.name]
         Setting.setting[property.name] = default

--- a/macast/utils.py
+++ b/macast/utils.py
@@ -202,7 +202,6 @@ class Setting:
         """
         if not bool(Setting.setting):
             Setting.load()
-            print(property)
         if property.name in Setting.setting:
             return Setting.setting[property.name]
         Setting.setting[property.name] = default

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -3,6 +3,7 @@ cherrypy
 lxml
 pillow
 requests
+tendo
 netifaces
 git+https://github.com/xfangfang/pystray.git
 git+https://github.com/xfangfang/pyperclip.git


### PR DESCRIPTION
#103 
I have made a quick and dirty way to check if an instance of the program is already running, by using the singleton module included in [tendo](https://github.com/pycontribs/tendo). It will create a dummy file in the default local temp folder (platform dependant) and check if the file existed. If the file exists, it will raise an error and quit the program.

## TODO:
1. Add a toggle option in the context menu. Currently, it needs to be changed in the `macast_setting.json` file. I don't quite understand how the context menu works. :(
2. A more elegant way to handle the program entry point.


