### PR TITLE
Added basic external subtitle pass-through, disabled cherrypy's autoreload

### DIFF
--- a/macast/ssdp.py
+++ b/macast/ssdp.py
@@ -164,7 +164,10 @@ class SSDPServer:
             cherrypy.engine.publish("app_notify", "Macast", "SSDP Can't start")
             threading.Thread(target=lambda: Setting.stop_service(), name="SSDP_STOP_THREAD").start()
             return
-        self.sock.settimeout(1)
+        if Setting.get(SettingProperty.Check_IP_Frequency, 5):
+            self.sock.settimeout(1)
+            # see @server/..if check_ip_freq:
+            # for same reason
 
         while self.running:
             try:

--- a/macast/utils.py
+++ b/macast/utils.py
@@ -77,6 +77,7 @@ class SettingProperty(Enum):
     Single_Mode = 13
     SSDP_Notify_Frequency = 14
     Check_IP_Frequency = 15
+    Thread_Pool_Max = 64
 
 
 class Setting:


### PR DESCRIPTION
## About external subtitles

To test the external subtitle function, you can use rclone serve dlna, which supports srt natively, and the source code can be simply changed to support ass and other formats.

As dlna clients, vlc and kodi support external subtitles. Bubble upnp on the phone can do something similar to Macast, but it can't control the player, it also supports the transfer of external subtitles.

## About disabling autoreload

Cherrypy's autoreload consumes resources, especially without inotify on windows. Not to mention
In actual use, the directory it monitors will not be touched at all.

* *Conveniently added judgment to the code that monitors ip changes, giving users the opportunity to completely disable the feature from the configuration file*