### PR TITLE
implement audio playback by setting force-window property

### DIFF
--- a/Macast.py
+++ b/Macast.py
@@ -3,6 +3,8 @@
 import os
 import sys
 import logging
+from distutils.spawn import find_executable
+
 from macast import Setting, SETTING_DIR
 from macast.macast import gui
 from macast.utils import SettingProperty, SingleInstance, SingleInstanceException
@@ -19,8 +21,10 @@ def get_base_path(path="."):
 
 
 def set_mpv_default_path():
-    mpv_path = 'mpv'
-    if sys.platform == 'darwin':
+    mpv_path = find_executable('mpv')
+    if mpv_path:
+        pass
+    elif sys.platform == 'darwin':
         mpv_path = get_base_path('bin/MacOS/mpv')
     elif sys.platform == 'win32':
         mpv_path = get_base_path('bin/mpv.exe')

--- a/macast_renderer/mpv.py
+++ b/macast_renderer/mpv.py
@@ -36,6 +36,10 @@ class ObserveProperty(Enum):
     track_list = 6
     speed = 7
     sub = 8
+    file_format = 9
+
+
+AudioFormat = ['m4a', 'mp3', 'wav', 'flac', 'ogg', 'mp2', 'amr']
 
 
 class MPVRenderer(Renderer):
@@ -157,6 +161,9 @@ class MPVRenderer(Renderer):
         self.send_command(
             ['observe_property', ObserveProperty.sub.value,
              'sub-visibility'])
+        self.send_command(
+            ['observe_property', ObserveProperty.file_format.value,
+             'file-format'])
 
         self.set_media_volume(Setting.get(SettingProperty.PlayerDefaultVolume, 100))
 
@@ -212,6 +219,13 @@ class MPVRenderer(Renderer):
                 data = res.get('data', None)
                 if data is not None:
                     self.set_state_subtitle(data)
+            elif res['id'] == ObserveProperty.file_format.value:
+                data = res.get('data', None)
+                fmts = data.split(',')
+                for fmt in fmts:
+                    if fmt.lower() in AudioFormat:
+                        self.send_command(['set_property', 'force-window', 'yes'])
+                        break
         elif 'event' in res:
             logger.info(res)
             if res['event'] == 'end-file':


### PR DESCRIPTION
Happy new year!

This pr provides an easy implementation to support audio playback for #18 

Firstly, declare a list that contains some common formats of music application. (e.g. m4a for Netease Music, mp3 for QQ Music)

Secondly, add a new item to observed_property, [file_format](https://mpv.io/manual/master/#command-interface-file-format).

Thirdly, if Macast find a casting file format in the AudioFormat, send a command to set `--force-window` property so that mpv window will display as the music starts to play. [reference of why we can set options at runtime, see the 'Note' below the title](https://mpv.io/manual/master/#property-list).

Finally, while casting a song from Netease Music, Macast's behaviour is as follow.

![audio-playback](https://user-images.githubusercontent.com/73600915/214769145-b25ddf51-08ac-4d17-b27f-e6f7864c1bc5.jpg)

Looking forward to your code review :)

